### PR TITLE
Adaptive misassembly penalty

### DIFF
--- a/veritymap/config/config_tm2_hifi.tsv
+++ b/veritymap/config/config_tm2_hifi.tsv
@@ -6,7 +6,7 @@ max_rare_cnt_target 10
 max_rare_cnt_query  1
 k_step_size 50
 k_window_size   30000
-window_unique_density   0.9
+window_unique_density   0.99
 strategy    approximate
 false_positive_probability  0.01
 exp_base    0.01

--- a/veritymap/config/config_tm2_hifi.tsv
+++ b/veritymap/config/config_tm2_hifi.tsv
@@ -18,6 +18,7 @@ min_score   0
 max_top_score_prop  0.9
 max_jump    100000
 misassembly_penalty_base    100
+misassembly_penalty_mult    10000
 diff_penalty_mult   1
 min_chain_range 5000
 max_supp_dist_diff  5

--- a/veritymap/config/config_tm2_hifi.tsv
+++ b/veritymap/config/config_tm2_hifi.tsv
@@ -5,10 +5,10 @@ min_end_ident   0.997
 max_rare_cnt_target 10
 max_rare_cnt_query  1
 k_step_size 50
-k_window_size   100000
-window_unique_density   0.99
+k_window_size   30000
+window_unique_density   0.9
 strategy    approximate
-false_positive_probability  1e-03
+false_positive_probability  0.01
 exp_base    0.01
 nhash   5
 chunk_size 5000000

--- a/veritymap/config/config_tm2_ont.tsv
+++ b/veritymap/config/config_tm2_ont.tsv
@@ -5,10 +5,10 @@ min_end_ident   0.9
 max_rare_cnt_target 30
 max_rare_cnt_query  1
 k_step_size 10
-k_window_size   100000
-window_unique_density   0.99
+k_window_size   30000
+window_unique_density   0.9
 strategy    approximate
-false_positive_probability  1e-03
+false_positive_probability  0.01
 exp_base    0.01
 nhash   5
 chunk_size 5000000

--- a/veritymap/config/config_tm2_ont.tsv
+++ b/veritymap/config/config_tm2_ont.tsv
@@ -18,6 +18,7 @@ min_score   0
 max_top_score_prop  0.9
 max_jump    100000
 misassembly_penalty_base    1000
+misassembly_penalty_mult    10000
 diff_penalty_mult   10
 min_chain_range 5000
 max_supp_dist_diff  5

--- a/veritymap/src/projects/veritymap/config/config.cpp
+++ b/veritymap/src/projects/veritymap/config/config.cpp
@@ -42,8 +42,7 @@ Config Config::load_config_file(const std::filesystem::path& config_fn) {
                                          stod(m.at("min_score")),
                                          stod(m.at("max_top_score_prop")),
                                          stoll(m.at("max_jump")),
-                                         stod(m.at("misassembly_penalty_base"))
-                                             /stod(m.at("k")),
+                                         stod(m.at("misassembly_penalty_base")),
                                          stod(m.at("misassembly_penalty_mult")),
                                          stod(m.at("diff_penalty_mult")),
                                          stoull(m.at("min_chain_range")),

--- a/veritymap/src/projects/veritymap/config/config.cpp
+++ b/veritymap/src/projects/veritymap/config/config.cpp
@@ -42,7 +42,9 @@ Config Config::load_config_file(const std::filesystem::path& config_fn) {
                                          stod(m.at("min_score")),
                                          stod(m.at("max_top_score_prop")),
                                          stoll(m.at("max_jump")),
-                                         stod(m.at("misassembly_penalty_base")) / stod(m.at("k")),
+                                         stod(m.at("misassembly_penalty_base"))
+                                             /stod(m.at("k")),
+                                         stod(m.at("misassembly_penalty_mult")),
                                          stod(m.at("diff_penalty_mult")),
                                          stoull(m.at("min_chain_range")),
                                          stoull(m.at("max_supp_dist_diff")),

--- a/veritymap/src/projects/veritymap/config/config.hpp
+++ b/veritymap/src/projects/veritymap/config/config.hpp
@@ -67,7 +67,8 @@ struct Config {
     double max_top_score_prop;
     match_pos_type max_jump;
     score_type misassembly_penalty;
-    score_type diff_penalty_mult;
+      score_type misassembly_penalty_mult;
+      score_type diff_penalty_mult;
     size_t min_chain_range;
     size_t max_supp_dist_diff;
     // static_assert(min_chain_range / KmerIndexerParams::k_step_size >= min_matches);

--- a/veritymap/src/projects/veritymap/dp_scoring.hpp
+++ b/veritymap/src/projects/veritymap/dp_scoring.hpp
@@ -50,24 +50,32 @@ ScoresBacktracks get_scores(const matches::Matches& matches,
       }
 
       const match_pos_type jump_penalty = std::min(std::abs(query_jump), std::abs(target_jump));
-      const match_pos_type dist_diff = std::abs(std::abs(query_jump) - std::abs(target_jump));
+        const match_pos_type
+            dist_diff = std::abs(std::abs(query_jump) - std::abs(target_jump));
 
-      const score_type diff_penalty = dist_diff <= chaining_params.max_supp_dist_diff ? 0 : static_cast<score_type>(dist_diff) / (jump_penalty + 1);
+        const score_type diff_penalty =
+            dist_diff <= chaining_params.max_supp_dist_diff ? 0 :
+            static_cast<score_type>(dist_diff)/(jump_penalty + 1);
 
-      const score_type overlap_penalty =
-          std::min<score_type>(1, static_cast<score_type>(query_jump + common_params.k) / common_params.k);
+        const score_type overlap_penalty =
+            std::min<score_type>(1,
+                                 static_cast<score_type>(query_jump
+                                     + common_params.k)/common_params.k);
 
-      if (overlap_penalty < 1) {
-        VERIFY(diff_penalty == 0);
-      }
-      const score_type cur_score = *sc_it + freq_weight * overlap_penalty - std::min(chaining_params.diff_penalty_mult * diff_penalty, chaining_params.misassembly_penalty);
+        if (overlap_penalty < 1) {
+            VERIFY(diff_penalty==0);
+        }
+        score_type cur_score = *sc_it + freq_weight*overlap_penalty -
+            std::min(chaining_params.diff_penalty_mult*diff_penalty,
+                     chaining_params.misassembly_penalty*(1
+                         + dist_diff/chaining_params.misassembly_penalty_mult));
 
-      if (cur_score > score) {
-        score = cur_score;
-        VERIFY(scores.size() - 1 >= sc_it - scores.rbegin());
-        backtrack = scores.size() - 1 - (sc_it - scores.rbegin());
-        VERIFY(backtrack < scores.size());
-      }
+        if (cur_score > score) {
+            score = cur_score;
+            VERIFY(scores.size() - 1 >= sc_it - scores.rbegin());
+            backtrack = scores.size() - 1 - (sc_it - scores.rbegin());
+            VERIFY(backtrack < scores.size());
+        }
     }
     VERIFY(score >= freq_weight);
     scores.emplace_back(score);


### PR DESCRIPTION
Introduces an additional parameter to take care of insertions into perfect tandem repeats.
VerityMap will prefer the shortest insertion.

Depends on https://github.com/ablab/VerityMap/pull/10 and should be merged afterwards.