### PR TITLE
Remove unnecessary division of mism penalty by k

### DIFF
--- a/veritymap/src/projects/veritymap/config/config.cpp
+++ b/veritymap/src/projects/veritymap/config/config.cpp
@@ -42,7 +42,7 @@ Config Config::load_config_file(const std::filesystem::path& config_fn) {
                                          stod(m.at("min_score")),
                                          stod(m.at("max_top_score_prop")),
                                          stoll(m.at("max_jump")),
-                                         stod(m.at("misassembly_penalty_base")) / stod(m.at("k")),
+                                         stod(m.at("misassembly_penalty_base")),
                                          stod(m.at("diff_penalty_mult")),
                                          stoull(m.at("min_chain_range")),
                                          stoull(m.at("max_supp_dist_diff")),


### PR DESCRIPTION
Remove unnecessary division of mism penalty by k while reading the config