### PR TITLE
Fix compilation on centOS with gcc 11.2.0

### DIFF
--- a/veritymap/Makefile
+++ b/veritymap/Makefile
@@ -12,7 +12,7 @@ veritymap: cmake
 	$(MAKE) -C build all
 	mkdir -p build/bin
 	mv $(abspath build/src/projects/veritymap/veritymap) build/bin/veritymap
-	-rm -r build/bin/config
+	rm -rf build/bin/config
 	mv $(abspath build/src/projects/veritymap/config) build/bin
 
 test_launch: veritymap

--- a/veritymap/src/projects/veritymap/kmer_index/target_indexer.hpp
+++ b/veritymap/src/projects/veritymap/kmer_index/target_indexer.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <optional>
+
 #include <sequences/contigs.hpp>
 #include <sequences/seqio.hpp>
 

--- a/veritymap/src/tools/sketch/include/sketch/div.h
+++ b/veritymap/src/tools/sketch/include/sketch/div.h
@@ -146,14 +146,6 @@ template<> struct Schismatic<uint32_t> {
         return div_t<uint32_t> {tmpd, v - d_ * tmpd};
     }
 };
-template<> struct Schismatic<int32_t>: Schismatic<uint32_t> {
-    template<typename...Args>Schismatic<int32_t>(Args &&...args):
-        Schismatic<uint32_t>(std::forward<Args>(args)...){}
-};
-template<> struct Schismatic<int64_t>: Schismatic<uint64_t> {
-    template<typename...Args>Schismatic<int64_t>(Args &&...args):
-        Schismatic<uint64_t>(std::forward<Args>(args)...){}
-};
 
 } // namespace schism
 


### PR DESCRIPTION
I had to make some tweaks to get this to compile/run on my compute server:

- Used `rm -f` instead of `-rm` so that `make` doesn't report itself as having failed if the config doesn't already exist
- Added a missing include of `<optional>`
- Removed the variadic constructors for `Schismatic`. For some reason, these are parsed as a syntax error by `gcc` 11.2.0. I don't fully understand what the problem is, but it seems like they weren't used anywhere in this codebase anyway.

Resolves https://github.com/ablab/VerityMap/issues/22